### PR TITLE
Fix race npe

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -1,0 +1,12 @@
+# Branches
+
+- develop
+- emf2.15 (branches with fixes for 2.15 emf version)
+
+# Changelog
+
+## org.eclipse.emf.ecore 2.15.0.11
+- Fixed NPE when concurrently setting same feature of multiple objects
+
+## org.eclipse.emf.ecore 2.15.0.10
+- Fixed features equals

--- a/plugins/org.eclipse.emf.ecore/pom.xml
+++ b/plugins/org.eclipse.emf.ecore/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.eclipse.emf</groupId>
   <artifactId>org.eclipse.emf.ecore</artifactId>
-  <version>2.15.0.10</version>
+  <version>2.15.0.11</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/plugins/org.eclipse.emf.ecore/src/org/eclipse/emf/ecore/impl/EStructuralFeatureImpl.java
+++ b/plugins/org.eclipse.emf.ecore/src/org/eclipse/emf/ecore/impl/EStructuralFeatureImpl.java
@@ -2164,8 +2164,8 @@ public abstract class EStructuralFeatureImpl extends ETypedElementImpl implement
         };
     }
 
-    protected Object defaultValue;
-    protected Object intrinsicDefaultValue;
+    protected volatile Object defaultValue;
+    protected volatile Object intrinsicDefaultValue;
 
     /**
      * @since 2.9

--- a/plugins/org.eclipse.emf.ecore/src/org/eclipse/emf/ecore/impl/EStructuralFeatureImpl.java
+++ b/plugins/org.eclipse.emf.ecore/src/org/eclipse/emf/ecore/impl/EStructuralFeatureImpl.java
@@ -831,7 +831,7 @@ public abstract class EStructuralFeatureImpl extends ETypedElementImpl implement
 
   protected EStructuralFeature.Internal.SettingDelegate settingDelegate;
 
-  public EStructuralFeature.Internal.SettingDelegate getSettingDelegate()
+  public synchronized EStructuralFeature.Internal.SettingDelegate getSettingDelegate()
   {
     if (settingDelegate == null)
     {


### PR DESCRIPTION
Пробовал на java 11 (liberica) и java 17 (adopt), поведение разное. 

## Java 11

Воспроизводится при одновременной записи null в свойство недавно созданного объекта.

В dynamicSet intrinsicDefaultValue может оказаться null из-за гонки в getSettingDelegate, тогда newValue останется null и произойдет исключение.

```java
if (newValue == null)
{
  if (intrinsicDefaultValue != null)
  {
    settings.dynamicSet(index, null);
    newValue = defaultValue;
  }
  else if (defaultValue != null)
  {
    settings.dynamicSet(index, NIL);
  }
  else
  {
    settings.dynamicSet(index, null);
  }
}
```

Тест для воспроизведения:

```java
package repro;

import org.eclipse.emf.common.notify.impl.AdapterImpl;
import org.eclipse.emf.ecore.*;
import org.openjdk.jcstress.annotations.*;
import org.openjdk.jcstress.infra.results.I_Result;

@JCStressTest
@State
@Outcome(expect = Expect.ACCEPTABLE)
public class ReproMulti {

  final EPackage pkg;
  final EClass cls;
  final EAttribute attr;

  public ReproMulti() {
    pkg = EcoreFactory.eINSTANCE.createEPackage();
    pkg.setName("p");
    pkg.setNsURI("p");
    pkg.setNsPrefix("p");

    EDataType intType = EcoreFactory.eINSTANCE.createEDataType();
    intType.setName("Int");
    intType.setInstanceClass(int.class);
    intType.setSerializable(true);
    pkg.getEClassifiers().add(intType);

    cls = EcoreFactory.eINSTANCE.createEClass();
    cls.setName("C");
    pkg.getEClassifiers().add(cls);

    attr = EcoreFactory.eINSTANCE.createEAttribute();
    attr.setName("x");
    attr.setEType(intType);
    attr.setDefaultValueLiteral("1");
    cls.getEStructuralFeatures().add(attr);
  }

  @Actor
  public void a21() {
    EObject o = pkg.getEFactoryInstance().create(cls);
    o.eAdapters().add(new AdapterImpl() {});
    o.eSet(attr, null);
  }

  @Actor
  public void a3() {
    try
    {
      EObject o = pkg.getEFactoryInstance().create(cls);
      o.eAdapters().add(new AdapterImpl()
      {
      });
      o.eSet(attr, 12);
    }
    catch (Exception e)
    {
      e.printStackTrace();
      throw e;
    }
  }

  @Arbiter
  public void arbiter(I_Result r) {
    r.r1 = 0;
  }
}
```

и чинится добавлением синхронизации:
```diff
- public EStructuralFeature.Internal.SettingDelegate getSettingDelegate()
+ public synchronized EStructuralFeature.Internal.SettingDelegate getSettingDelegate()
```

## Java 17

Тут другая проблема, теоретически может появиться и на java 11 (но в данный момент не воспроизводится).

Воспроизводится при одновременной записи в одно и то же свойство недавно созданных объектов.

Тест для воспроизведения:

```java
package repro;

import org.eclipse.emf.common.notify.impl.AdapterImpl;
import org.eclipse.emf.ecore.*;
import org.openjdk.jcstress.annotations.*;
import org.openjdk.jcstress.infra.results.I_Result;

@JCStressTest
@State
@Outcome(expect = Expect.ACCEPTABLE)
public class ReproMulti {

  final EPackage pkg;
  final EClass cls;
  final EAttribute attr;

  public ReproMulti() {
    pkg = EcoreFactory.eINSTANCE.createEPackage();
    pkg.setName("p");
    pkg.setNsURI("p");
    pkg.setNsPrefix("p");

    EDataType intType = EcoreFactory.eINSTANCE.createEDataType();
    intType.setName("Int");
    intType.setInstanceClass(int.class);
    intType.setSerializable(true);
    pkg.getEClassifiers().add(intType);

    cls = EcoreFactory.eINSTANCE.createEClass();
    cls.setName("C");
    pkg.getEClassifiers().add(cls);

    attr = EcoreFactory.eINSTANCE.createEAttribute();
    attr.setName("x");
    attr.setEType(intType);
    attr.setDefaultValueLiteral("1");
    cls.getEStructuralFeatures().add(attr);
  }

  @Actor
  public void a1() {
    EObject o = pkg.getEFactoryInstance().create(cls);
    o.eAdapters().add(new AdapterImpl() {});
    o.eSet(attr, 10);
  }

  @Actor
  public void a2() {
    EObject o = pkg.getEFactoryInstance().create(cls);
    o.eAdapters().add(new AdapterImpl() {});
    o.eSet(attr, 11);
  }

  @Actor
  public void a3() {
    try
    {
      EObject o = pkg.getEFactoryInstance().create(cls);
      o.eAdapters().add(new AdapterImpl()
      {
      });
      o.eSet(attr, 12);
    }
    catch (Exception e)
    {
      e.printStackTrace();
    }
  }

  @Arbiter
  public void arbiter(I_Result r) {
    r.r1 = 0;
  }
}
```
и чинится добавлением volatile:

```diff
-    protected Object defaultValue;
-    protected Object intrinsicDefaultValue;
+    protected volatile Object defaultValue;
+    protected volatile Object intrinsicDefaultValue;
```